### PR TITLE
Chore: AWS S3 - Branch is not permitted error 해결

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,3 +33,5 @@ deploy:
     acl: private
     local_dir: deploy
     wait-until-deployed: true
+    on:
+      all_branches: true


### PR DESCRIPTION
내용 : Skipping a deployment with the s3 provider because this branch is not permitted: main
`on:
       all_branches: true` 옵션 추가